### PR TITLE
Filterset adjustments: Route, Notebook, Image, Tag

### DIFF
--- a/sparrow/core/views.py
+++ b/sparrow/core/views.py
@@ -15,7 +15,8 @@ class RouteViewSet(ModelViewSet):
 
     # search & options for filtering and ordering
     filterset_fields = ['verified', 'user__baseUser__username', 'user__baseUser__first_name', 'user__baseUser__last_name',
-                        'group__name', 'isWithin__attraction__name', 'isWithin__attraction__isTagged__tag__tagName']
+                        'group__name', 'isWithin__attraction__name', 'isWithin__attraction__isTagged__tag__tagName',
+                        'notebook__id', 'user__id', 'group__id']
     search_fields = ['title', 'description', 'startingPointLat', 'startingPointLon']
     ordering_fields = ['startingPointLat', 'startingPointLon']
 
@@ -189,7 +190,8 @@ class BelongsToViewSet(ModelViewSet):
 # notebook viewset
 class NotebookViewSet(ModelViewSet):
     queryset = Notebook.objects.all()
-        
+    filterset_fields = ["user__id"]
+
     def get_serializer_class(self):
 
         if self.request.method in permissions.SAFE_METHODS: # get, head, options


### PR DESCRIPTION
Additional filterset are required in order to be able to query by foreign keys. I have added filterset adjustments for this 
ModelViewSets:
- Route:  notebook_id, user_id, group_id( to be able to query routes that belong to a specific user, group or notebook)
- Notebook: user__id( to be able to query notebooks that belong to a specific user)

_NOTE!_ The filtersets for Image and Tag view sets will be added after the viewsets are created. Do not merge until than.