### PR TITLE
erased route_id

### DIFF
--- a/sparrow/core/views.py
+++ b/sparrow/core/views.py
@@ -250,7 +250,7 @@ class RatingFlagTypeViewSet(GenericViewSet, mixins.ListModelMixin, mixins.Retrie
 class TagViewSet(GenericViewSet, mixins.ListModelMixin, mixins.RetrieveModelMixin):
     queryset = Tag.objects.all()
     serializer_class = TagSerializer
-    filterset_fields = ['route_id', 'attraction_id', 'isTagged__attraction_id']
+    filterset_fields = ['isTagged__attraction']
 
 
 class IsTaggedViewSet(GenericViewSet,mixins.RetrieveModelMixin, mixins.CreateModelMixin, mixins.DestroyModelMixin):


### PR DESCRIPTION
erased route_id from TagViewSet : filterset_fields
Should we care about the route_ids?
Only if we are interested in the routes that contain a certain attraction. 