### PR TITLE
Rating flag bug fix

### DIFF
--- a/sparrow/core/serializers.py
+++ b/sparrow/core/serializers.py
@@ -547,6 +547,17 @@ class RatingFlagSerializer(serializers.ModelSerializer):
         # the user making the request gets associated with the current RatingFlag
         validated_data['user'] = member
         
+        # the validation is performed on the updated rating object as if it were a new object being created, 
+        # and not taking into account any values that were previously set on the object
+        # this means that when updating a rating, there may be cases where the updated rating will have 
+        # both the route and attraction fields not equal to None
+        if validated_data.get('route') is not None and instance.route is None:
+            raise serializers.ValidationError({"non_field_errors": ["Only one of route or attraction can be specified."]})
+
+        if validated_data.get('attraction') is not None and instance.attraction is None:
+            raise serializers.ValidationError({"non_field_errors": ["Only one of route or attraction can be specified."]})
+
+
         return super().update(instance, validated_data)
 
 

--- a/sparrow/core/serializers.py
+++ b/sparrow/core/serializers.py
@@ -511,7 +511,7 @@ class NotebookSerializer(serializers.ModelSerializer):
 class RatingFlagSerializer(serializers.ModelSerializer):
     class Meta:
         model = RatingFlag
-        fields = ['user', 'rating', 'comment', 'route', 'attraction']
+        fields = ['rating', 'comment', 'route', 'attraction']
               
     def validate(self, data):
         route = data.get('route')

--- a/sparrow/core/serializers.py
+++ b/sparrow/core/serializers.py
@@ -511,8 +511,9 @@ class NotebookSerializer(serializers.ModelSerializer):
 class RatingFlagSerializer(serializers.ModelSerializer):
     class Meta:
         model = RatingFlag
-        fields = ['rating', 'comment', 'route', 'attraction']
-              
+        fields = ['user', 'rating', 'comment', 'route', 'attraction']
+        read_only_fields = ['user']
+        
     def validate(self, data):
         route = data.get('route')
         attraction = data.get('attraction')

--- a/sparrow/core/views.py
+++ b/sparrow/core/views.py
@@ -238,7 +238,7 @@ class RatingFlagViewSet(GenericViewSet, mixins.ListModelMixin, mixins.CreateMode
         
         # once created, the flags can be altered, which means
         # that the query set can be limitted to ratings
-        return RatingFlag.objects.get(rating_flag_type_id__lte=5)
+        return RatingFlag.objects.filter(rating_id__lte=5)
 
 
 class RatingFlagTypeViewSet(GenericViewSet, mixins.ListModelMixin, mixins.RetrieveModelMixin):


### PR DESCRIPTION
Adjustments I made:
1. made a few changes regarding ratingFlag filtering line
2. made the user field of the RatingFlag object read-only, as this field will always be equal to the authenticated user who made the request to create or update the object
3. fixed a bug in the code that updates a RatingFlag object: the bug occurred when an existing object was updated, and the updated object ended up having both the route and attraction fields set to a non-None value.